### PR TITLE
Flatten zip output before join-ing in full-justify()

### DIFF
--- a/lib/Form/TextFormatting.pm
+++ b/lib/Form/TextFormatting.pm
@@ -128,7 +128,7 @@ our sub full-justify(Str $line, Int $width, Str $space = ' ') {
 
 		@spaces.push('');
 
-		return (@words Z @spaces).join;
+		return (@words Z @spaces).flat.join;
 	}
 
 	return $line.substr(0, $width);


### PR DESCRIPTION
The flattening behaviour of some list operators has changed in a recent
version of Rakudo, such that in certain situations the output is no longer
flattened automatically.  When zipping together the words and spaces in
`full-justify()` a list of lists is created instead of a simple flat list.
Thus it is necessary to explicitly flatten this list before joining the
elements together.  This change makes the test suite pass with current
versions of Rakudo.
